### PR TITLE
Feat/UI fix credential form

### DIFF
--- a/frontend/src/app/(dashboard)/dashboard/credentials/new/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/credentials/new/page.tsx
@@ -3,10 +3,5 @@ import { CredentialIssuancePage } from '@/features/credentials/components/pages/
 // TODO: add auth guard once login flow is built
 // TODO: resolve organizationId and userId from authenticated session
 export default function Page() {
-  return (
-    <CredentialIssuancePage
-      organizationId="dev-org"
-      userId="dev-user"
-    />
-  );
+  return <CredentialIssuancePage organizationId="dev-org" userId="dev-user" />;
 }

--- a/frontend/src/app/(dashboard)/dashboard/credentials/new/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/credentials/new/page.tsx
@@ -1,32 +1,12 @@
-import { redirect } from 'next/navigation';
-import { createServerSupabaseClient } from '@/lib/supabase/server';
-import { createOrganizationRepository } from '@/features/organizations/repositories/organizationRepository';
-import { createOrganizationService } from '@/features/organizations/services/organizationService';
 import { CredentialIssuancePage } from '@/features/credentials/components/pages/CredentialIssuancePage';
-import { ROUTES } from '@/lib/constants/routes';
 
-export default async function Page() {
-  const supabase = await createServerSupabaseClient();
-
-  // TODO: define and use auth route constant once login flow is built
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
-
-  const orgRepo = createOrganizationRepository(supabase);
-  const orgService = createOrganizationService(orgRepo);
-  const internalUser = await orgService.resolveCurrentUser(user.id);
-
-  if (!internalUser) redirect('/login');
-
-  // TODO: check internalUser.role — only 'admin' | 'operator' can issue credentials
-  void ROUTES;
-
+// TODO: add auth guard once login flow is built
+// TODO: resolve organizationId and userId from authenticated session
+export default function Page() {
   return (
     <CredentialIssuancePage
-      organizationId={internalUser.organizationId}
-      userId={internalUser.id}
+      organizationId="dev-org"
+      userId="dev-user"
     />
   );
 }

--- a/frontend/src/features/credentials/components/pages/CredentialIssuancePage.tsx
+++ b/frontend/src/features/credentials/components/pages/CredentialIssuancePage.tsx
@@ -1,38 +1,114 @@
 'use client';
 
-import { IssuanceForm } from '../ui/IssuanceForm';
-import { useIssuanceDraft } from '../../hooks/useIssuanceDraft';
-import type { IssuanceDraftInput } from '../../schemas';
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/input';
+import { IconCertificate, IconSearch } from '@tabler/icons-react';
+import { Building2 } from 'lucide-react';
+import { MOCK_ENTREPRENEURS } from '@/features/entrepreneurs/data/mock-entrepreneurs';
+import { CredentialIssuanceModal } from '../ui/CredentialIssuanceModal';
 
 interface CredentialIssuancePageProps {
   organizationId: string;
   userId: string;
 }
 
-// TODO: redirect to draft detail page after successful creation
-// TODO: wire IssuanceOrchestrator.issue() call for the final "emit" step
-export function CredentialIssuancePage({
-  organizationId,
-  userId,
-}: CredentialIssuancePageProps) {
-  const { mutateAsync, isPending } = useIssuanceDraft({
-    organizationId,
-    createdBy: userId,
+export function CredentialIssuancePage({}: CredentialIssuancePageProps) {
+  const [search, setSearch] = useState('');
+  const [selectedEntrepreneur, setSelectedEntrepreneur] = useState<{
+    id: string;
+    name: string;
+    businessName: string;
+  } | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const filtered = MOCK_ENTREPRENEURS.filter((e) => {
+    const term = search.toLowerCase();
+    return (
+      e.name.toLowerCase().includes(term) ||
+      e.businessName.toLowerCase().includes(term)
+    );
   });
 
-  async function handleSubmit(data: IssuanceDraftInput) {
-    // TODO: navigate to draft review step
-    await mutateAsync(data);
-  }
+  const handleSelect = (entrepreneur: (typeof MOCK_ENTREPRENEURS)[number]) => {
+    setSelectedEntrepreneur({
+      id: entrepreneur.id,
+      name: entrepreneur.name,
+      businessName: entrepreneur.businessName,
+    });
+    setIsModalOpen(true);
+  };
 
   return (
-    <div className="mx-auto max-w-lg">
-      <h1 className="mb-6 text-2xl font-semibold text-gray-900">
-        Nueva credencial
-      </h1>
-      <div className="rounded-lg border border-gray-200 bg-white p-6">
-        <IssuanceForm onSubmit={handleSubmit} isLoading={isPending} />
+    <div className="mx-auto max-w-2xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-foreground">
+          Emitir Credencial
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Selecciona un empresario para emitir una credencial verificable.
+        </p>
       </div>
+
+      <div className="relative mb-4">
+        <IconSearch className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Buscar por nombre o negocio..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      <div className="space-y-2">
+        {filtered.map((entrepreneur) => (
+          <button
+            key={entrepreneur.id}
+            type="button"
+            onClick={() => handleSelect(entrepreneur)}
+            className="flex w-full items-center justify-between gap-4 rounded-xl border border-border bg-card p-4 text-left transition-all hover:border-primary/30 hover:shadow-md"
+          >
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold text-muted-foreground">
+                {entrepreneur.name
+                  .split(' ')
+                  .slice(0, 2)
+                  .map((n) => n[0])
+                  .join('')}
+              </div>
+              <div>
+                <p className="text-sm font-medium text-foreground">
+                  {entrepreneur.name}
+                </p>
+                <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <Building2 className="h-3 w-3" />
+                  {entrepreneur.businessName}
+                </p>
+              </div>
+            </div>
+            <Button size="sm" variant="outline" className="gap-1.5 shrink-0">
+              <IconCertificate className="h-4 w-4" />
+              Emitir
+            </Button>
+          </button>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="py-12 text-center text-sm text-muted-foreground">
+            No se encontraron empresarios con ese criterio.
+          </div>
+        )}
+      </div>
+
+      {selectedEntrepreneur && (
+        <CredentialIssuanceModal
+          open={isModalOpen}
+          onOpenChange={setIsModalOpen}
+          entrepreneurId={selectedEntrepreneur.id}
+          entrepreneurName={selectedEntrepreneur.name}
+          businessName={selectedEntrepreneur.businessName}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/features/credentials/components/ui/BehaviorCredentialForm.tsx
+++ b/frontend/src/features/credentials/components/ui/BehaviorCredentialForm.tsx
@@ -118,8 +118,7 @@ export function BehaviorCredentialForm({
     commercialStability: 'stable',
   });
 
-  const formatPercent = (n: number) =>
-    `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`;
+  const formatPercent = (n: number) => `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`;
 
   const formatRatio = (n: number) => n.toFixed(2);
 
@@ -143,9 +142,7 @@ export function BehaviorCredentialForm({
             render={({ field }) => (
               <Select
                 value={field.value}
-                onValueChange={(v: string | null) =>
-                  field.onChange(v ?? '')
-                }
+                onValueChange={(v: string | null) => field.onChange(v ?? '')}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Seleccionar" />
@@ -175,9 +172,7 @@ export function BehaviorCredentialForm({
             render={({ field }) => (
               <Select
                 value={field.value}
-                onValueChange={(v: string | null) =>
-                  field.onChange(v ?? '')
-                }
+                onValueChange={(v: string | null) => field.onChange(v ?? '')}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Seleccionar" />
@@ -240,10 +235,7 @@ export function BehaviorCredentialForm({
           </div>
           <div className="space-y-1.5">
             <Label>Moneda</Label>
-            <Input
-              {...register('activeCredit.currency')}
-              placeholder="COP"
-            />
+            <Input {...register('activeCredit.currency')} placeholder="COP" />
           </div>
           <div className="space-y-1.5">
             <Label>Estado</Label>
@@ -253,9 +245,7 @@ export function BehaviorCredentialForm({
               render={({ field }) => (
                 <Select
                   value={field.value ?? undefined}
-                  onValueChange={(v: string | null) =>
-                    field.onChange(v)
-                  }
+                  onValueChange={(v: string | null) => field.onChange(v)}
                 >
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder="Seleccionar" />
@@ -263,9 +253,7 @@ export function BehaviorCredentialForm({
                   <SelectContent>
                     <SelectItem value="current">Al día</SelectItem>
                     <SelectItem value="late">Mora</SelectItem>
-                    <SelectItem value="restructured">
-                      Reestructurado
-                    </SelectItem>
+                    <SelectItem value="restructured">Reestructurado</SelectItem>
                     <SelectItem value="closed">Cerrado</SelectItem>
                   </SelectContent>
                 </Select>
@@ -305,9 +293,7 @@ export function BehaviorCredentialForm({
             {...register('assets', { valueAsNumber: true })}
           />
           {errors.assets && (
-            <p className="text-xs text-destructive">
-              {errors.assets.message}
-            </p>
+            <p className="text-xs text-destructive">{errors.assets.message}</p>
           )}
         </div>
 
@@ -380,9 +366,7 @@ export function BehaviorCredentialForm({
                   <SelectItem value="partially_validated">
                     Parcialmente validado
                   </SelectItem>
-                  <SelectItem value="not_validated">
-                    No validado
-                  </SelectItem>
+                  <SelectItem value="not_validated">No validado</SelectItem>
                 </SelectContent>
               </Select>
             )}
@@ -396,9 +380,7 @@ export function BehaviorCredentialForm({
             {...register('newJobs', { valueAsNumber: true })}
           />
           {errors.newJobs && (
-            <p className="text-xs text-destructive">
-              {errors.newJobs.message}
-            </p>
+            <p className="text-xs text-destructive">{errors.newJobs.message}</p>
           )}
         </div>
       </div>
@@ -448,9 +430,7 @@ export function BehaviorCredentialForm({
                 <SelectContent>
                   <SelectItem value="improving">Mejorando</SelectItem>
                   <SelectItem value="stable">Estable</SelectItem>
-                  <SelectItem value="deteriorating">
-                    Deteriorándose
-                  </SelectItem>
+                  <SelectItem value="deteriorating">Deteriorándose</SelectItem>
                 </SelectContent>
               </Select>
             )}
@@ -462,7 +442,10 @@ export function BehaviorCredentialForm({
         <Button type="button" variant="outline" onClick={onBack}>
           &larr; Atrás
         </Button>
-        <Button type="submit" className="bg-accent hover:bg-accent/90 text-accent-foreground">
+        <Button
+          type="submit"
+          className="bg-accent hover:bg-accent/90 text-accent-foreground"
+        >
           Generar Credencial &rarr;
         </Button>
       </div>

--- a/frontend/src/features/credentials/components/ui/BehaviorCredentialForm.tsx
+++ b/frontend/src/features/credentials/components/ui/BehaviorCredentialForm.tsx
@@ -1,0 +1,471 @@
+'use client';
+
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/Button';
+import { IconShieldCheck } from '@tabler/icons-react';
+import { cn } from '@/lib/utils';
+import {
+  behaviorCredentialFormSchema,
+  computeBehaviorDerivedFields,
+  type BehaviorCredentialFormInput,
+} from '../../schemas/behaviorCredentialSchema';
+
+interface BehaviorCredentialFormProps {
+  onSubmit: (data: BehaviorCredentialFormInput) => void;
+  onBack: () => void;
+  defaultValues?: Partial<BehaviorCredentialFormInput>;
+}
+
+const CREDIT_SEGMENTS = [
+  'Microcrédito',
+  'Crédito individual',
+  'Grupo solidario',
+  'Banca comunal',
+] as const;
+
+function ToggleField({
+  value,
+  onChange,
+}: {
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex gap-0">
+      <button
+        type="button"
+        onClick={() => onChange(true)}
+        className={cn(
+          'flex-1 rounded-l-lg border px-4 py-2 text-sm font-medium transition-colors',
+          value
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-border bg-card text-muted-foreground hover:bg-muted',
+        )}
+      >
+        Sí
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange(false)}
+        className={cn(
+          'flex-1 rounded-r-lg border border-l-0 px-4 py-2 text-sm font-medium transition-colors',
+          !value
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-border bg-card text-muted-foreground hover:bg-muted',
+        )}
+      >
+        No
+      </button>
+    </div>
+  );
+}
+
+export function BehaviorCredentialForm({
+  onSubmit,
+  onBack,
+  defaultValues,
+}: BehaviorCredentialFormProps) {
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<BehaviorCredentialFormInput>({
+    resolver: zodResolver(behaviorCredentialFormSchema),
+    defaultValues: {
+      activeCredit: { exists: false },
+      monthlyIncomeStability: 'medium',
+      registryValidation: 'not_validated',
+      commercialStability: 'stable',
+      financialTrend: 'stable',
+      newJobs: 0,
+      averageSales: 0,
+      costsAndExpenses: 0,
+      assets: 0,
+      liabilities: 0,
+      ...defaultValues,
+    },
+  });
+
+  const averageSales = watch('averageSales');
+  const costsAndExpenses = watch('costsAndExpenses');
+  const assets = watch('assets');
+  const liabilities = watch('liabilities');
+  const activeCreditExists = watch('activeCredit.exists');
+
+  const derived = computeBehaviorDerivedFields({
+    averageSales: averageSales || 0,
+    costsAndExpenses: costsAndExpenses || 0,
+    assets: assets || 0,
+    liabilities: liabilities || 0,
+    financialTrend: watch('financialTrend') || 'stable',
+    creditSegmentStart: '',
+    creditSegmentEnd: '',
+    monthlyIncomeStability: 'medium',
+    registryValidation: 'not_validated',
+    newJobs: 0,
+    commercialStability: 'stable',
+  });
+
+  const formatPercent = (n: number) =>
+    `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`;
+
+  const formatRatio = (n: number) => n.toFixed(2);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      <div className="flex items-center gap-2 pb-2">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-teal-50 text-teal-600">
+          <IconShieldCheck className="h-5 w-5" />
+        </div>
+        <h3 className="text-base font-semibold">
+          Credencial de Comportamiento
+        </h3>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="creditSegmentStart">Segmento inicio</Label>
+          <Controller
+            control={control}
+            name="creditSegmentStart"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? '')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  {CREDIT_SEGMENTS.map((seg) => (
+                    <SelectItem key={seg} value={seg}>
+                      {seg}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          />
+          {errors.creditSegmentStart && (
+            <p className="text-xs text-destructive">
+              {errors.creditSegmentStart.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="creditSegmentEnd">Segmento final</Label>
+          <Controller
+            control={control}
+            name="creditSegmentEnd"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? '')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  {CREDIT_SEGMENTS.map((seg) => (
+                    <SelectItem key={seg} value={seg}>
+                      {seg}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          />
+          {errors.creditSegmentEnd && (
+            <p className="text-xs text-destructive">
+              {errors.creditSegmentEnd.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Crédito vigente</Label>
+          <Controller
+            control={control}
+            name="activeCredit.exists"
+            render={({ field }) => (
+              <ToggleField
+                value={field.value ?? false}
+                onChange={field.onChange}
+              />
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="averageSales">Ventas mensuales (COP) *</Label>
+          <Input
+            type="number"
+            {...register('averageSales', { valueAsNumber: true })}
+          />
+          {errors.averageSales && (
+            <p className="text-xs text-destructive">
+              {errors.averageSales.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {activeCreditExists && (
+        <div className="grid grid-cols-3 gap-4 rounded-lg border border-border bg-muted/30 p-3">
+          <div className="space-y-1.5">
+            <Label>Monto</Label>
+            <Input
+              type="number"
+              {...register('activeCredit.amount', { valueAsNumber: true })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Moneda</Label>
+            <Input
+              {...register('activeCredit.currency')}
+              placeholder="COP"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Estado</Label>
+            <Controller
+              control={control}
+              name="activeCredit.status"
+              render={({ field }) => (
+                <Select
+                  value={field.value ?? undefined}
+                  onValueChange={(v: string | null) =>
+                    field.onChange(v)
+                  }
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Seleccionar" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="current">Al día</SelectItem>
+                    <SelectItem value="late">Mora</SelectItem>
+                    <SelectItem value="restructured">
+                      Reestructurado
+                    </SelectItem>
+                    <SelectItem value="closed">Cerrado</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="costsAndExpenses">Costos mensuales (COP) *</Label>
+          <Input
+            type="number"
+            {...register('costsAndExpenses', { valueAsNumber: true })}
+          />
+          {errors.costsAndExpenses && (
+            <p className="text-xs text-destructive">
+              {errors.costsAndExpenses.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Margen operativo estimado</Label>
+          <div className="flex h-8 items-center rounded-lg bg-muted px-3 text-sm text-muted-foreground">
+            {formatPercent(derived.estimatedOperatingMargin)}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="assets">Activos totales (COP)</Label>
+          <Input
+            type="number"
+            {...register('assets', { valueAsNumber: true })}
+          />
+          {errors.assets && (
+            <p className="text-xs text-destructive">
+              {errors.assets.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="liabilities">Pasivos totales (COP)</Label>
+          <Input
+            type="number"
+            {...register('liabilities', { valueAsNumber: true })}
+          />
+          {errors.liabilities && (
+            <p className="text-xs text-destructive">
+              {errors.liabilities.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Relación pasivos/activos</Label>
+          <div className="flex h-8 items-center rounded-lg bg-muted px-3 text-sm text-muted-foreground">
+            {formatRatio(derived.liabilitiesToAssetsRatio)}
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Estabilidad del negocio</Label>
+          <Controller
+            control={control}
+            name="commercialStability"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'stable')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="stable">Estable</SelectItem>
+                  <SelectItem value="seasonal">Estacional</SelectItem>
+                  <SelectItem value="volatile">Volátil</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Validación de registro</Label>
+          <Controller
+            control={control}
+            name="registryValidation"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'not_validated')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="validated">Validado</SelectItem>
+                  <SelectItem value="partially_validated">
+                    Parcialmente validado
+                  </SelectItem>
+                  <SelectItem value="not_validated">
+                    No validado
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="newJobs">Nuevos empleos</Label>
+          <Input
+            type="number"
+            {...register('newJobs', { valueAsNumber: true })}
+          />
+          {errors.newJobs && (
+            <p className="text-xs text-destructive">
+              {errors.newJobs.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Estabilidad de ingresos</Label>
+          <Controller
+            control={control}
+            name="monthlyIncomeStability"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'medium')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="high">Alta</SelectItem>
+                  <SelectItem value="medium">Media</SelectItem>
+                  <SelectItem value="low">Baja</SelectItem>
+                  <SelectItem value="volatile">Volátil</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Tendencia financiera</Label>
+          <Controller
+            control={control}
+            name="financialTrend"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'stable')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="improving">Mejorando</SelectItem>
+                  <SelectItem value="stable">Estable</SelectItem>
+                  <SelectItem value="deteriorating">
+                    Deteriorándose
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-border pt-4">
+        <Button type="button" variant="outline" onClick={onBack}>
+          &larr; Atrás
+        </Button>
+        <Button type="submit" className="bg-accent hover:bg-accent/90 text-accent-foreground">
+          Generar Credencial &rarr;
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/credentials/components/ui/CredentialIssuanceModal.tsx
+++ b/frontend/src/features/credentials/components/ui/CredentialIssuanceModal.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/Button';
+import { cn } from '@/lib/utils';
+import { X } from 'lucide-react';
+import type { CredentialType } from '../../types';
+import { CredentialTypeSelector } from './CredentialTypeSelector';
+import { BehaviorCredentialForm } from './BehaviorCredentialForm';
+import { ImpactCredentialForm } from './ImpactCredentialForm';
+import { ProfileCredentialForm } from './ProfileCredentialForm';
+import { CredentialIssuedSuccess } from './CredentialIssuedSuccess';
+import type { BehaviorCredentialFormInput } from '../../schemas/behaviorCredentialSchema';
+import type { ImpactCredentialFormInput } from '../../schemas/impactCredentialSchema';
+import type { ProfileCredentialFormInput } from '../../schemas/profileCredentialSchema';
+
+type FormData =
+  | BehaviorCredentialFormInput
+  | ImpactCredentialFormInput
+  | ProfileCredentialFormInput;
+
+interface CredentialIssuanceModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entrepreneurId: string;
+  entrepreneurName: string;
+  businessName: string;
+}
+
+const STEPS = [
+  { number: 1, label: 'Tipo' },
+  { number: 2, label: 'Datos' },
+  { number: 3, label: 'Emitida' },
+] as const;
+
+function Stepper({ currentStep }: { currentStep: number }) {
+  return (
+    <div className="flex items-center gap-3">
+      {STEPS.map((step, i) => {
+        const isActive = step.number <= currentStep;
+        const isCurrent = step.number === currentStep;
+        return (
+          <div key={step.number} className="flex items-center gap-2">
+            {i > 0 && (
+              <div
+                className={cn(
+                  'h-0.5 w-6 transition-colors',
+                  step.number <= currentStep ? 'bg-white' : 'bg-white/30',
+                )}
+              />
+            )}
+            <div className="flex items-center gap-1.5">
+              <span
+                className={cn(
+                  'flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold transition-colors',
+                  isCurrent
+                    ? 'bg-accent text-accent-foreground'
+                    : isActive
+                      ? 'bg-white/90 text-primary'
+                      : 'bg-white/20 text-white/60',
+                )}
+              >
+                {step.number}
+              </span>
+              <span
+                className={cn(
+                  'text-sm font-medium',
+                  isActive ? 'text-white' : 'text-white/50',
+                )}
+              >
+                {step.label}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function CredentialIssuanceModal({
+  open,
+  onOpenChange,
+  entrepreneurId,
+  entrepreneurName,
+  businessName,
+}: CredentialIssuanceModalProps) {
+  const [step, setStep] = useState(1);
+  const [selectedType, setSelectedType] = useState<CredentialType | null>(null);
+  const [, setFormData] = useState<FormData | null>(null);
+
+  const resetState = useCallback(() => {
+    setStep(1);
+    setSelectedType(null);
+    setFormData(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) resetState();
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, resetState],
+  );
+
+  const handleTypeSelect = (type: CredentialType) => {
+    setSelectedType(type);
+  };
+
+  const handleContinueToData = () => {
+    if (selectedType) setStep(2);
+  };
+
+  const handleFormSubmit = (data: FormData) => {
+    setFormData(data);
+
+    // TODO: ACTA integration
+    // 1. Build W3C VC 2.0 payload from form data
+    // 2. Call useCredential().issue() with the payload
+    // 3. Store the credential in the database
+    // 4. On success, transition to step 3
+
+    void entrepreneurId;
+    setStep(3);
+  };
+
+  const handleBack = () => {
+    setStep(1);
+  };
+
+  const handleClose = () => {
+    handleOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="sm:max-w-2xl p-0 gap-0 overflow-hidden"
+      >
+        {/* Header */}
+        <div className="bg-[var(--color-brand-blue,#0B1F3F)] px-6 py-4 text-white">
+          <div className="flex items-start justify-between">
+            <div>
+              <h2 className="text-lg font-bold">
+                Emitir Credencial Verificable
+              </h2>
+              <p className="text-sm text-white/70">
+                {entrepreneurName} &middot; {businessName}
+              </p>
+            </div>
+            <DialogClose
+              render={
+                <button
+                  type="button"
+                  className="rounded-md p-1 text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              }
+            />
+          </div>
+          <div className="mt-4">
+            <Stepper currentStep={step} />
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="max-h-[60vh] overflow-y-auto px-6 py-5">
+          {step === 1 && (
+            <div className="space-y-6">
+              <CredentialTypeSelector
+                selected={selectedType}
+                onSelect={handleTypeSelect}
+              />
+              <div className="flex justify-end">
+                <Button
+                  onClick={handleContinueToData}
+                  disabled={!selectedType}
+                  className="bg-accent hover:bg-accent/90 text-accent-foreground"
+                >
+                  Continuar &rarr;
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {step === 2 && selectedType === 'behavior' && (
+            <BehaviorCredentialForm
+              onSubmit={handleFormSubmit}
+              onBack={handleBack}
+            />
+          )}
+
+          {step === 2 && selectedType === 'impact' && (
+            <ImpactCredentialForm
+              onSubmit={handleFormSubmit}
+              onBack={handleBack}
+            />
+          )}
+
+          {step === 2 && selectedType === 'profile' && (
+            <ProfileCredentialForm
+              onSubmit={handleFormSubmit}
+              onBack={handleBack}
+            />
+          )}
+
+          {step === 3 && selectedType && (
+            <CredentialIssuedSuccess
+              credentialType={selectedType}
+              entrepreneurName={entrepreneurName}
+              businessName={businessName}
+              onClose={handleClose}
+            />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/features/credentials/components/ui/CredentialIssuanceModal.tsx
+++ b/frontend/src/features/credentials/components/ui/CredentialIssuanceModal.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogClose,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogClose } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/lib/utils';
 import { X } from 'lucide-react';

--- a/frontend/src/features/credentials/components/ui/CredentialIssuedSuccess.tsx
+++ b/frontend/src/features/credentials/components/ui/CredentialIssuedSuccess.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { Button } from '@/components/ui/Button';
+import { Badge } from '@/components/ui/Badge';
+import { CheckCircle, ExternalLink } from 'lucide-react';
+import {
+  IconTrendingUp,
+  IconShieldCheck,
+  IconIdBadge2,
+} from '@tabler/icons-react';
+import type { CredentialType } from '../../types';
+import { CREDENTIAL_TYPE_LABELS } from '../../types';
+
+const TYPE_ICONS: Record<CredentialType, React.ReactNode> = {
+  impact: <IconTrendingUp className="h-6 w-6 text-orange-500" />,
+  behavior: <IconShieldCheck className="h-6 w-6 text-teal-600" />,
+  profile: <IconIdBadge2 className="h-6 w-6 text-blue-600" />,
+};
+
+interface CredentialIssuedSuccessProps {
+  credentialType: CredentialType;
+  entrepreneurName: string;
+  businessName: string;
+  onClose: () => void;
+}
+
+export function CredentialIssuedSuccess({
+  credentialType,
+  entrepreneurName,
+  businessName,
+  onClose,
+}: CredentialIssuedSuccessProps) {
+  return (
+    <div className="flex flex-col items-center gap-6 py-6 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-emerald-50">
+        <CheckCircle className="h-8 w-8 text-emerald-500" />
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold text-foreground">
+          Credencial lista para emitir
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          Los datos han sido validados y la credencial está preparada.
+        </p>
+      </div>
+
+      <div className="w-full max-w-sm space-y-3 rounded-xl border border-border bg-muted/30 p-4">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Tipo</span>
+          <div className="flex items-center gap-2">
+            {TYPE_ICONS[credentialType]}
+            <span className="text-sm font-medium">
+              {CREDENTIAL_TYPE_LABELS[credentialType]}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Empresario</span>
+          <span className="text-sm font-medium">{entrepreneurName}</span>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Negocio</span>
+          <span className="text-sm font-medium">{businessName}</span>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Estado</span>
+          <Badge variant="success" className="gap-1">
+            <CheckCircle className="h-3 w-3" />
+            Validada
+          </Badge>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Blockchain</span>
+          {/* TODO: ACTA integration - show actual tx hash */}
+          <span className="text-xs text-muted-foreground italic">
+            Pendiente de emisión on-chain
+          </span>
+        </div>
+      </div>
+
+      <div className="w-full max-w-sm rounded-lg border border-dashed border-amber-300 bg-amber-50 p-3">
+        <p className="text-xs text-amber-700">
+          La emisión on-chain con ACTA será habilitada próximamente. Los datos
+          del formulario quedarán almacenados como borrador hasta entonces.
+        </p>
+      </div>
+
+      <div className="flex w-full max-w-sm gap-3">
+        {/* TODO: ACTA integration - enable this button to view on explorer */}
+        <Button variant="outline" className="flex-1 gap-2" disabled>
+          <ExternalLink className="h-4 w-4" />
+          Ver en blockchain
+        </Button>
+        <Button
+          className="flex-1 bg-accent hover:bg-accent/90 text-accent-foreground"
+          onClick={onClose}
+        >
+          Cerrar
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/credentials/components/ui/CredentialTypeSelector.tsx
+++ b/frontend/src/features/credentials/components/ui/CredentialTypeSelector.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import {
+  IconTrendingUp,
+  IconShieldCheck,
+  IconIdBadge2,
+} from '@tabler/icons-react';
+import type { CredentialType } from '../../types';
+import {
+  CREDENTIAL_TYPE_LABELS,
+  CREDENTIAL_TYPE_DESCRIPTIONS,
+} from '../../types';
+
+const TYPE_CONFIG: Record<
+  CredentialType,
+  { icon: React.ReactNode; iconBg: string; iconColor: string }
+> = {
+  impact: {
+    icon: <IconTrendingUp className="h-6 w-6" />,
+    iconBg: 'bg-orange-50',
+    iconColor: 'text-orange-500',
+  },
+  behavior: {
+    icon: <IconShieldCheck className="h-6 w-6" />,
+    iconBg: 'bg-teal-50',
+    iconColor: 'text-teal-600',
+  },
+  profile: {
+    icon: <IconIdBadge2 className="h-6 w-6" />,
+    iconBg: 'bg-blue-50',
+    iconColor: 'text-blue-600',
+  },
+};
+
+const TYPES: CredentialType[] = ['impact', 'behavior', 'profile'];
+
+interface CredentialTypeSelectorProps {
+  selected: CredentialType | null;
+  onSelect: (type: CredentialType) => void;
+}
+
+export function CredentialTypeSelector({
+  selected,
+  onSelect,
+}: CredentialTypeSelectorProps) {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm font-medium text-muted-foreground">
+        Selecciona el tipo de credencial a emitir:
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {TYPES.map((type) => {
+          const config = TYPE_CONFIG[type];
+          const isSelected = selected === type;
+
+          return (
+            <button
+              key={type}
+              type="button"
+              onClick={() => onSelect(type)}
+              className={cn(
+                'flex flex-col items-start gap-3 rounded-xl border-2 p-4 text-left transition-all hover:shadow-md',
+                isSelected
+                  ? 'border-primary bg-primary/5 shadow-sm'
+                  : 'border-border bg-card hover:border-muted-foreground/30',
+              )}
+            >
+              <div
+                className={cn(
+                  'flex h-10 w-10 items-center justify-center rounded-lg',
+                  config.iconBg,
+                  config.iconColor,
+                )}
+              >
+                {config.icon}
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-foreground">
+                  {CREDENTIAL_TYPE_LABELS[type]}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {CREDENTIAL_TYPE_DESCRIPTIONS[type]}
+                </p>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/credentials/components/ui/ImpactCredentialForm.tsx
+++ b/frontend/src/features/credentials/components/ui/ImpactCredentialForm.tsx
@@ -80,8 +80,7 @@ export function ImpactCredentialForm({
     businessTrend: 'stable',
   });
 
-  const formatPercent = (n: number) =>
-    `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`;
+  const formatPercent = (n: number) => `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`;
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
@@ -111,9 +110,7 @@ export function ImpactCredentialForm({
             render={({ field }) => (
               <Select
                 value={field.value || undefined}
-                onValueChange={(v: string | null) =>
-                  field.onChange(v ?? '')
-                }
+                onValueChange={(v: string | null) => field.onChange(v ?? '')}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Seleccionar" />
@@ -129,9 +126,7 @@ export function ImpactCredentialForm({
             )}
           />
           {errors.sector && (
-            <p className="text-xs text-destructive">
-              {errors.sector.message}
-            </p>
+            <p className="text-xs text-destructive">{errors.sector.message}</p>
           )}
         </div>
       </div>
@@ -244,9 +239,7 @@ export function ImpactCredentialForm({
                 <SelectContent>
                   <SelectItem value="growing">En crecimiento</SelectItem>
                   <SelectItem value="stable">Estable</SelectItem>
-                  <SelectItem value="deteriorating">
-                    En deterioro
-                  </SelectItem>
+                  <SelectItem value="deteriorating">En deterioro</SelectItem>
                 </SelectContent>
               </Select>
             )}
@@ -261,17 +254,11 @@ export function ImpactCredentialForm({
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-1.5">
             <Label htmlFor="assessmentPeriod.startDate">Fecha inicio</Label>
-            <Input
-              type="date"
-              {...register('assessmentPeriod.startDate')}
-            />
+            <Input type="date" {...register('assessmentPeriod.startDate')} />
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="assessmentPeriod.endDate">Fecha fin</Label>
-            <Input
-              type="date"
-              {...register('assessmentPeriod.endDate')}
-            />
+            <Input type="date" {...register('assessmentPeriod.endDate')} />
           </div>
         </div>
       </div>
@@ -280,7 +267,10 @@ export function ImpactCredentialForm({
         <Button type="button" variant="outline" onClick={onBack}>
           &larr; Atrás
         </Button>
-        <Button type="submit" className="bg-accent hover:bg-accent/90 text-accent-foreground">
+        <Button
+          type="submit"
+          className="bg-accent hover:bg-accent/90 text-accent-foreground"
+        >
           Generar Credencial &rarr;
         </Button>
       </div>

--- a/frontend/src/features/credentials/components/ui/ImpactCredentialForm.tsx
+++ b/frontend/src/features/credentials/components/ui/ImpactCredentialForm.tsx
@@ -1,0 +1,289 @@
+'use client';
+
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/Button';
+import { IconTrendingUp } from '@tabler/icons-react';
+import {
+  impactCredentialFormSchema,
+  computeImpactDerivedFields,
+  type ImpactCredentialFormInput,
+} from '../../schemas/impactCredentialSchema';
+
+interface ImpactCredentialFormProps {
+  onSubmit: (data: ImpactCredentialFormInput) => void;
+  onBack: () => void;
+  defaultValues?: Partial<ImpactCredentialFormInput>;
+}
+
+const SECTORS = [
+  'Alimentos y bebidas',
+  'Comercio',
+  'Manufactura',
+  'Servicios',
+  'Tecnología',
+  'Agropecuario',
+  'Textil y confecciones',
+  'Artesanías',
+  'Turismo',
+  'Otro',
+] as const;
+
+export function ImpactCredentialForm({
+  onSubmit,
+  onBack,
+  defaultValues,
+}: ImpactCredentialFormProps) {
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<ImpactCredentialFormInput>({
+    resolver: zodResolver(impactCredentialFormSchema),
+    defaultValues: {
+      companyName: '',
+      sector: '',
+      yearsInOperation: 0,
+      salesPreviousYear: 0,
+      salesCurrentYear: 0,
+      currentEmployees: 0,
+      newJobsCreated: 0,
+      newFormalJobsCreated: 0,
+      businessTrend: 'stable',
+      ...defaultValues,
+    },
+  });
+
+  const salesPreviousYear = watch('salesPreviousYear');
+  const salesCurrentYear = watch('salesCurrentYear');
+
+  const derived = computeImpactDerivedFields({
+    salesPreviousYear: salesPreviousYear || 0,
+    salesCurrentYear: salesCurrentYear || 0,
+    companyName: '',
+    sector: '',
+    yearsInOperation: 0,
+    currentEmployees: 0,
+    newJobsCreated: 0,
+    newFormalJobsCreated: 0,
+    businessTrend: 'stable',
+  });
+
+  const formatPercent = (n: number) =>
+    `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      <div className="flex items-center gap-2 pb-2">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-orange-50 text-orange-500">
+          <IconTrendingUp className="h-5 w-5" />
+        </div>
+        <h3 className="text-base font-semibold">Credencial de Impacto</h3>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="companyName">Nombre de la empresa *</Label>
+          <Input {...register('companyName')} placeholder="Ej: Tienda Verde" />
+          {errors.companyName && (
+            <p className="text-xs text-destructive">
+              {errors.companyName.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Sector *</Label>
+          <Controller
+            control={control}
+            name="sector"
+            render={({ field }) => (
+              <Select
+                value={field.value || undefined}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? '')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  {SECTORS.map((s) => (
+                    <SelectItem key={s} value={s}>
+                      {s}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          />
+          {errors.sector && (
+            <p className="text-xs text-destructive">
+              {errors.sector.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="yearsInOperation">Años en operación</Label>
+          <Input
+            type="number"
+            {...register('yearsInOperation', { valueAsNumber: true })}
+          />
+          {errors.yearsInOperation && (
+            <p className="text-xs text-destructive">
+              {errors.yearsInOperation.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="salesPreviousYear">Ventas año anterior (COP)</Label>
+          <Input
+            type="number"
+            {...register('salesPreviousYear', { valueAsNumber: true })}
+          />
+          {errors.salesPreviousYear && (
+            <p className="text-xs text-destructive">
+              {errors.salesPreviousYear.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="salesCurrentYear">Ventas año actual (COP)</Label>
+          <Input
+            type="number"
+            {...register('salesCurrentYear', { valueAsNumber: true })}
+          />
+          {errors.salesCurrentYear && (
+            <p className="text-xs text-destructive">
+              {errors.salesCurrentYear.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label>Variación de ventas</Label>
+        <div className="flex h-8 items-center rounded-lg bg-muted px-3 text-sm text-muted-foreground">
+          {formatPercent(derived.salesVariationPercent)}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="currentEmployees">Empleados actuales</Label>
+          <Input
+            type="number"
+            {...register('currentEmployees', { valueAsNumber: true })}
+          />
+          {errors.currentEmployees && (
+            <p className="text-xs text-destructive">
+              {errors.currentEmployees.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="newJobsCreated">Nuevos empleos</Label>
+          <Input
+            type="number"
+            {...register('newJobsCreated', { valueAsNumber: true })}
+          />
+          {errors.newJobsCreated && (
+            <p className="text-xs text-destructive">
+              {errors.newJobsCreated.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="newFormalJobsCreated">Empleos formales</Label>
+          <Input
+            type="number"
+            {...register('newFormalJobsCreated', { valueAsNumber: true })}
+          />
+          {errors.newFormalJobsCreated && (
+            <p className="text-xs text-destructive">
+              {errors.newFormalJobsCreated.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Tendencia del negocio</Label>
+          <Controller
+            control={control}
+            name="businessTrend"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'stable')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="growing">En crecimiento</SelectItem>
+                  <SelectItem value="stable">Estable</SelectItem>
+                  <SelectItem value="deteriorating">
+                    En deterioro
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-muted-foreground">
+          Período de evaluación (opcional)
+        </Label>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="assessmentPeriod.startDate">Fecha inicio</Label>
+            <Input
+              type="date"
+              {...register('assessmentPeriod.startDate')}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="assessmentPeriod.endDate">Fecha fin</Label>
+            <Input
+              type="date"
+              {...register('assessmentPeriod.endDate')}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-border pt-4">
+        <Button type="button" variant="outline" onClick={onBack}>
+          &larr; Atrás
+        </Button>
+        <Button type="submit" className="bg-accent hover:bg-accent/90 text-accent-foreground">
+          Generar Credencial &rarr;
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/credentials/components/ui/IssuanceForm.tsx
+++ b/frontend/src/features/credentials/components/ui/IssuanceForm.tsx
@@ -52,8 +52,8 @@ export function IssuanceForm({
           className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
         >
           <option value="impact">Impacto</option>
-          <option value="verification">Verificación</option>
-          <option value="endorsement">Endorsement</option>
+          <option value="behavior">Comportamiento</option>
+          <option value="profile">Perfil y Formalización</option>
         </select>
       </div>
 

--- a/frontend/src/features/credentials/components/ui/ProfileCredentialForm.tsx
+++ b/frontend/src/features/credentials/components/ui/ProfileCredentialForm.tsx
@@ -1,0 +1,442 @@
+'use client';
+
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/Button';
+import { IconIdBadge2 } from '@tabler/icons-react';
+import { cn } from '@/lib/utils';
+import {
+  profileCredentialFormSchema,
+  type ProfileCredentialFormInput,
+} from '../../schemas/profileCredentialSchema';
+
+interface ProfileCredentialFormProps {
+  onSubmit: (data: ProfileCredentialFormInput) => void;
+  onBack: () => void;
+  defaultValues?: Partial<ProfileCredentialFormInput>;
+}
+
+function ToggleField({
+  value,
+  onChange,
+}: {
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex gap-0">
+      <button
+        type="button"
+        onClick={() => onChange(true)}
+        className={cn(
+          'flex-1 rounded-l-lg border px-4 py-2 text-sm font-medium transition-colors',
+          value
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-border bg-card text-muted-foreground hover:bg-muted',
+        )}
+      >
+        Sí
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange(false)}
+        className={cn(
+          'flex-1 rounded-r-lg border border-l-0 px-4 py-2 text-sm font-medium transition-colors',
+          !value
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-border bg-card text-muted-foreground hover:bg-muted',
+        )}
+      >
+        No
+      </button>
+    </div>
+  );
+}
+
+export function ProfileCredentialForm({
+  onSubmit,
+  onBack,
+  defaultValues,
+}: ProfileCredentialFormProps) {
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<ProfileCredentialFormInput>({
+    resolver: zodResolver(profileCredentialFormSchema),
+    defaultValues: {
+      identityValidated: false,
+      educationLevel: 'secondary',
+      municipality: '',
+      zone: 'urban',
+      mainHouseholdProvider: false,
+      householdIncome: 0,
+      formalizedBusiness: false,
+      nit: null,
+      yearsInOperation: 0,
+      companySize: 'micro',
+      internetAccess: false,
+      employmentFormalization: { formalizedJobsCount: 0 },
+      traceabilityLevel: 'medium',
+      formalizationLevel: 'low',
+      applicantStabilitySignal: 'moderate',
+      ...defaultValues,
+    },
+  });
+
+  const formalizedBusiness = watch('formalizedBusiness');
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+      <div className="flex items-center gap-2 pb-2">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+          <IconIdBadge2 className="h-5 w-5" />
+        </div>
+        <h3 className="text-base font-semibold">
+          Credencial de Perfil y Formalización
+        </h3>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Identidad validada</Label>
+          <Controller
+            control={control}
+            name="identityValidated"
+            render={({ field }) => (
+              <ToggleField value={field.value} onChange={field.onChange} />
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Nivel educativo</Label>
+          <Controller
+            control={control}
+            name="educationLevel"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'secondary')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">Ninguno</SelectItem>
+                  <SelectItem value="primary">Primaria</SelectItem>
+                  <SelectItem value="secondary">Secundaria</SelectItem>
+                  <SelectItem value="technical">Técnico</SelectItem>
+                  <SelectItem value="undergraduate">
+                    Universitario
+                  </SelectItem>
+                  <SelectItem value="postgraduate">Posgrado</SelectItem>
+                  <SelectItem value="other">Otro</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="municipality">Municipio *</Label>
+          <Input
+            {...register('municipality')}
+            placeholder="Ej: Medellín"
+          />
+          {errors.municipality && (
+            <p className="text-xs text-destructive">
+              {errors.municipality.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Zona</Label>
+          <Controller
+            control={control}
+            name="zone"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'urban')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="urban">Urbano</SelectItem>
+                  <SelectItem value="rural">Rural</SelectItem>
+                  <SelectItem value="periurban">Periurbano</SelectItem>
+                  <SelectItem value="other">Otro</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Proveedor principal del hogar</Label>
+          <Controller
+            control={control}
+            name="mainHouseholdProvider"
+            render={({ field }) => (
+              <ToggleField value={field.value} onChange={field.onChange} />
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="householdIncome">Ingreso del hogar (COP)</Label>
+          <Input
+            type="number"
+            {...register('householdIncome', { valueAsNumber: true })}
+          />
+          {errors.householdIncome && (
+            <p className="text-xs text-destructive">
+              {errors.householdIncome.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-1.5">
+          <Label>Negocio formalizado</Label>
+          <Controller
+            control={control}
+            name="formalizedBusiness"
+            render={({ field }) => (
+              <ToggleField value={field.value} onChange={field.onChange} />
+            )}
+          />
+        </div>
+
+        {formalizedBusiness && (
+          <div className="space-y-1.5">
+            <Label htmlFor="nit">NIT</Label>
+            <Input
+              {...register('nit')}
+              placeholder="Ej: 900123456-7"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="yearsInOperation">Años en operación</Label>
+          <Input
+            type="number"
+            {...register('yearsInOperation', { valueAsNumber: true })}
+          />
+          {errors.yearsInOperation && (
+            <p className="text-xs text-destructive">
+              {errors.yearsInOperation.message}
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Tamaño de empresa</Label>
+          <Controller
+            control={control}
+            name="companySize"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'micro')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="micro">Micro</SelectItem>
+                  <SelectItem value="small">Pequeña</SelectItem>
+                  <SelectItem value="medium">Mediana</SelectItem>
+                  <SelectItem value="large">Grande</SelectItem>
+                  <SelectItem value="unknown">Desconocido</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Acceso a internet</Label>
+          <Controller
+            control={control}
+            name="internetAccess"
+            render={({ field }) => (
+              <ToggleField value={field.value} onChange={field.onChange} />
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-4">
+        <p className="text-sm font-medium">Seguridad social (opcional)</p>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label>Tiene seguridad social</Label>
+            <Controller
+              control={control}
+              name="socialSecurityCoverage.hasSocialSecurity"
+              render={({ field }) => (
+                <ToggleField
+                  value={field.value ?? false}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Tiene pensión</Label>
+            <Controller
+              control={control}
+              name="socialSecurityCoverage.hasPension"
+              render={({ field }) => (
+                <ToggleField
+                  value={field.value ?? false}
+                  onChange={field.onChange}
+                />
+              )}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-4">
+        <p className="text-sm font-medium">Formalización del empleo</p>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label>Empleos formales</Label>
+            <Input
+              type="number"
+              {...register('employmentFormalization.formalizedJobsCount', {
+                valueAsNumber: true,
+              })}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Empleos informales</Label>
+            <Input
+              type="number"
+              {...register('employmentFormalization.informalJobsCount', {
+                valueAsNumber: true,
+              })}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-1.5">
+          <Label>Nivel de trazabilidad</Label>
+          <Controller
+            control={control}
+            name="traceabilityLevel"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'medium')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="high">Alto</SelectItem>
+                  <SelectItem value="medium">Medio</SelectItem>
+                  <SelectItem value="low">Bajo</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Nivel de formalización</Label>
+          <Controller
+            control={control}
+            name="formalizationLevel"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'low')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="high">Alto</SelectItem>
+                  <SelectItem value="medium">Medio</SelectItem>
+                  <SelectItem value="low">Bajo</SelectItem>
+                  <SelectItem value="none">Ninguno</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label>Señal de estabilidad</Label>
+          <Controller
+            control={control}
+            name="applicantStabilitySignal"
+            render={({ field }) => (
+              <Select
+                value={field.value}
+                onValueChange={(v: string | null) =>
+                  field.onChange(v ?? 'moderate')
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="strong">Fuerte</SelectItem>
+                  <SelectItem value="moderate">Moderada</SelectItem>
+                  <SelectItem value="weak">Débil</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between border-t border-border pt-4">
+        <Button type="button" variant="outline" onClick={onBack}>
+          &larr; Atrás
+        </Button>
+        <Button type="submit" className="bg-accent hover:bg-accent/90 text-accent-foreground">
+          Generar Credencial &rarr;
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/features/credentials/components/ui/ProfileCredentialForm.tsx
+++ b/frontend/src/features/credentials/components/ui/ProfileCredentialForm.tsx
@@ -140,9 +140,7 @@ export function ProfileCredentialForm({
                   <SelectItem value="primary">Primaria</SelectItem>
                   <SelectItem value="secondary">Secundaria</SelectItem>
                   <SelectItem value="technical">Técnico</SelectItem>
-                  <SelectItem value="undergraduate">
-                    Universitario
-                  </SelectItem>
+                  <SelectItem value="undergraduate">Universitario</SelectItem>
                   <SelectItem value="postgraduate">Posgrado</SelectItem>
                   <SelectItem value="other">Otro</SelectItem>
                 </SelectContent>
@@ -155,10 +153,7 @@ export function ProfileCredentialForm({
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-1.5">
           <Label htmlFor="municipality">Municipio *</Label>
-          <Input
-            {...register('municipality')}
-            placeholder="Ej: Medellín"
-          />
+          <Input {...register('municipality')} placeholder="Ej: Medellín" />
           {errors.municipality && (
             <p className="text-xs text-destructive">
               {errors.municipality.message}
@@ -234,10 +229,7 @@ export function ProfileCredentialForm({
         {formalizedBusiness && (
           <div className="space-y-1.5">
             <Label htmlFor="nit">NIT</Label>
-            <Input
-              {...register('nit')}
-              placeholder="Ej: 900123456-7"
-            />
+            <Input {...register('nit')} placeholder="Ej: 900123456-7" />
           </div>
         )}
       </div>
@@ -385,9 +377,7 @@ export function ProfileCredentialForm({
             render={({ field }) => (
               <Select
                 value={field.value}
-                onValueChange={(v: string | null) =>
-                  field.onChange(v ?? 'low')
-                }
+                onValueChange={(v: string | null) => field.onChange(v ?? 'low')}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Seleccionar" />
@@ -433,7 +423,10 @@ export function ProfileCredentialForm({
         <Button type="button" variant="outline" onClick={onBack}>
           &larr; Atrás
         </Button>
-        <Button type="submit" className="bg-accent hover:bg-accent/90 text-accent-foreground">
+        <Button
+          type="submit"
+          className="bg-accent hover:bg-accent/90 text-accent-foreground"
+        >
           Generar Credencial &rarr;
         </Button>
       </div>

--- a/frontend/src/features/credentials/schemas/behaviorCredentialSchema.ts
+++ b/frontend/src/features/credentials/schemas/behaviorCredentialSchema.ts
@@ -30,7 +30,9 @@ export type BehaviorCredentialFormInput = z.infer<
   typeof behaviorCredentialFormSchema
 >;
 
-export function computeBehaviorDerivedFields(data: BehaviorCredentialFormInput) {
+export function computeBehaviorDerivedFields(
+  data: BehaviorCredentialFormInput,
+) {
   const estimatedOperatingMargin =
     data.averageSales > 0
       ? ((data.averageSales - data.costsAndExpenses) / data.averageSales) * 100
@@ -64,8 +66,7 @@ export function computeBehaviorDerivedFields(data: BehaviorCredentialFormInput) 
 
   return {
     estimatedOperatingMargin: Math.round(estimatedOperatingMargin * 100) / 100,
-    liabilitiesToAssetsRatio:
-      Math.round(liabilitiesToAssetsRatio * 100) / 100,
+    liabilitiesToAssetsRatio: Math.round(liabilitiesToAssetsRatio * 100) / 100,
     estimatedOperationalCapacity,
     leverageLevel,
     paymentCapacitySignal,

--- a/frontend/src/features/credentials/schemas/behaviorCredentialSchema.ts
+++ b/frontend/src/features/credentials/schemas/behaviorCredentialSchema.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod';
+
+export const activeCreditSchema = z.object({
+  exists: z.boolean(),
+  amount: z.number().min(0).optional(),
+  currency: z.string().optional(),
+  status: z.enum(['current', 'late', 'restructured', 'closed']).optional(),
+});
+
+export const behaviorCredentialFormSchema = z.object({
+  creditSegmentStart: z.string().min(1, 'Segmento inicio es requerido'),
+  creditSegmentEnd: z.string().min(1, 'Segmento final es requerido'),
+  activeCredit: activeCreditSchema.nullable().optional(),
+  averageSales: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  costsAndExpenses: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  assets: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  liabilities: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  monthlyIncomeStability: z.enum(['high', 'medium', 'low', 'volatile']),
+  registryValidation: z.enum([
+    'validated',
+    'partially_validated',
+    'not_validated',
+  ]),
+  newJobs: z.number().int().min(0, 'Debe ser mayor o igual a 0'),
+  commercialStability: z.enum(['stable', 'seasonal', 'volatile']),
+  financialTrend: z.enum(['improving', 'stable', 'deteriorating']),
+});
+
+export type BehaviorCredentialFormInput = z.infer<
+  typeof behaviorCredentialFormSchema
+>;
+
+export function computeBehaviorDerivedFields(data: BehaviorCredentialFormInput) {
+  const estimatedOperatingMargin =
+    data.averageSales > 0
+      ? ((data.averageSales - data.costsAndExpenses) / data.averageSales) * 100
+      : 0;
+
+  const liabilitiesToAssetsRatio =
+    data.assets > 0 ? data.liabilities / data.assets : 0;
+
+  const estimatedOperationalCapacity: 'strong' | 'moderate' | 'weak' =
+    estimatedOperatingMargin >= 30
+      ? 'strong'
+      : estimatedOperatingMargin >= 10
+        ? 'moderate'
+        : 'weak';
+
+  const leverageLevel: 'low' | 'moderate' | 'high' =
+    liabilitiesToAssetsRatio <= 0.3
+      ? 'low'
+      : liabilitiesToAssetsRatio <= 0.6
+        ? 'moderate'
+        : 'high';
+
+  const paymentCapacitySignal: 'strong' | 'acceptable' | 'weak' | 'critical' =
+    estimatedOperationalCapacity === 'strong' && leverageLevel === 'low'
+      ? 'strong'
+      : estimatedOperationalCapacity === 'weak' || leverageLevel === 'high'
+        ? data.financialTrend === 'deteriorating'
+          ? 'critical'
+          : 'weak'
+        : 'acceptable';
+
+  return {
+    estimatedOperatingMargin: Math.round(estimatedOperatingMargin * 100) / 100,
+    liabilitiesToAssetsRatio:
+      Math.round(liabilitiesToAssetsRatio * 100) / 100,
+    estimatedOperationalCapacity,
+    leverageLevel,
+    paymentCapacitySignal,
+  };
+}

--- a/frontend/src/features/credentials/schemas/impactCredentialSchema.ts
+++ b/frontend/src/features/credentials/schemas/impactCredentialSchema.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const assessmentPeriodSchema = z.object({
+  startDate: z.string().min(1, 'Fecha de inicio es requerida'),
+  endDate: z.string().min(1, 'Fecha de fin es requerida'),
+});
+
+export const impactCredentialFormSchema = z.object({
+  companyName: z.string().min(1, 'Nombre de empresa es requerido'),
+  sector: z.string().min(1, 'Sector es requerido'),
+  yearsInOperation: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  salesPreviousYear: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  salesCurrentYear: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  currentEmployees: z.number().int().min(0, 'Debe ser mayor o igual a 0'),
+  newJobsCreated: z.number().int().min(0, 'Debe ser mayor o igual a 0'),
+  newFormalJobsCreated: z.number().int().min(0, 'Debe ser mayor o igual a 0'),
+  businessTrend: z.enum(['growing', 'stable', 'deteriorating']),
+  assessmentPeriod: assessmentPeriodSchema.optional(),
+});
+
+export type ImpactCredentialFormInput = z.infer<
+  typeof impactCredentialFormSchema
+>;
+
+export function computeImpactDerivedFields(data: ImpactCredentialFormInput) {
+  const salesVariationPercent =
+    data.salesPreviousYear > 0
+      ? ((data.salesCurrentYear - data.salesPreviousYear) /
+          data.salesPreviousYear) *
+        100
+      : 0;
+
+  return {
+    salesVariationPercent: Math.round(salesVariationPercent * 100) / 100,
+  };
+}

--- a/frontend/src/features/credentials/schemas/index.ts
+++ b/frontend/src/features/credentials/schemas/index.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const CredentialTypeSchema = z.enum([
   'impact',
-  'verification',
-  'endorsement',
+  'behavior',
+  'profile',
 ]);
 export const CredentialStatusSchema = z.enum([
   'draft',

--- a/frontend/src/features/credentials/schemas/index.ts
+++ b/frontend/src/features/credentials/schemas/index.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod';
 
-export const CredentialTypeSchema = z.enum([
-  'impact',
-  'behavior',
-  'profile',
-]);
+export const CredentialTypeSchema = z.enum(['impact', 'behavior', 'profile']);
 export const CredentialStatusSchema = z.enum([
   'draft',
   'issued',

--- a/frontend/src/features/credentials/schemas/profileCredentialSchema.ts
+++ b/frontend/src/features/credentials/schemas/profileCredentialSchema.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+export const socialSecurityCoverageSchema = z.object({
+  hasSocialSecurity: z.boolean(),
+  hasPension: z.boolean(),
+  notes: z.string().optional(),
+});
+
+export const employmentFormalizationSchema = z.object({
+  formalizedJobsCount: z.number().int().min(0, 'Debe ser mayor o igual a 0'),
+  informalJobsCount: z.number().int().min(0).optional(),
+});
+
+export const profileCredentialFormSchema = z.object({
+  identityValidated: z.boolean(),
+  educationLevel: z.enum([
+    'none',
+    'primary',
+    'secondary',
+    'technical',
+    'undergraduate',
+    'postgraduate',
+    'other',
+  ]),
+  municipality: z.string().min(1, 'Municipio es requerido'),
+  zone: z.enum(['urban', 'rural', 'periurban', 'other']),
+  mainHouseholdProvider: z.boolean(),
+  householdIncome: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  formalizedBusiness: z.boolean(),
+  nit: z.string().nullable().optional(),
+  yearsInOperation: z.number().min(0, 'Debe ser mayor o igual a 0'),
+  legalForm: z.string().nullable().optional(),
+  companySize: z.enum(['micro', 'small', 'medium', 'large', 'unknown']),
+  internetAccess: z.boolean(),
+  socialSecurityCoverage: socialSecurityCoverageSchema.optional(),
+  employmentFormalization: employmentFormalizationSchema,
+  traceabilityLevel: z.enum(['high', 'medium', 'low']),
+  formalizationLevel: z.enum(['high', 'medium', 'low', 'none']),
+  applicantStabilitySignal: z.enum(['strong', 'moderate', 'weak']),
+});
+
+export type ProfileCredentialFormInput = z.infer<
+  typeof profileCredentialFormSchema
+>;

--- a/frontend/src/features/credentials/types/index.ts
+++ b/frontend/src/features/credentials/types/index.ts
@@ -4,7 +4,30 @@ export type CredentialStatus =
   | 'revoked'
   | 'expired'
   | 'pending_endorsement';
-export type CredentialType = 'impact' | 'verification' | 'endorsement';
+export type CredentialType = 'impact' | 'behavior' | 'profile';
+
+export type VCCredentialType =
+  | 'ImpactCredential'
+  | 'BehaviorCredential'
+  | 'ProfileFormalizationCredential';
+
+export const CREDENTIAL_TYPE_TO_VC: Record<CredentialType, VCCredentialType> = {
+  impact: 'ImpactCredential',
+  behavior: 'BehaviorCredential',
+  profile: 'ProfileFormalizationCredential',
+};
+
+export const CREDENTIAL_TYPE_LABELS: Record<CredentialType, string> = {
+  impact: 'Credencial de Impacto',
+  behavior: 'Credencial de Comportamiento',
+  profile: 'Credencial de Perfil y Formalización',
+};
+
+export const CREDENTIAL_TYPE_DESCRIPTIONS: Record<CredentialType, string> = {
+  impact: 'Mide el impacto económico y social del empresario',
+  behavior: 'Refleja el comportamiento financiero y crediticio',
+  profile: 'Documenta el perfil y nivel de formalización',
+};
 export type RelationshipType =
   | 'endorses'
   | 'verifies'

--- a/frontend/src/features/entrepreneurs/components/pages/EntrepreneurDetailPage.tsx
+++ b/frontend/src/features/entrepreneurs/components/pages/EntrepreneurDetailPage.tsx
@@ -46,6 +46,8 @@ import {
   BADGE_ICONS_LARGE,
   getBadgeColors,
 } from '../../constants/badge-ui';
+import { CredentialIssuanceModal } from '@/features/credentials/components/ui/CredentialIssuanceModal';
+import { IconCertificate } from '@tabler/icons-react';
 
 interface EntrepreneurDetailPageProps {
   entrepreneurId: string;
@@ -58,6 +60,7 @@ export function EntrepreneurDetailPage({
   const [isBadgeDialogOpen, setIsBadgeDialogOpen] = useState(false);
   const [certifyDialogOpen, setCertifyDialogOpen] = useState(false);
   const [selectedStageId, setSelectedStageId] = useState<number | null>(null);
+  const [isCredentialModalOpen, setIsCredentialModalOpen] = useState(false);
 
   const entrepreneur = MOCK_ENTREPRENEURS.find((e) => e.id === entrepreneurId);
 
@@ -164,7 +167,17 @@ export function EntrepreneurDetailPage({
             </div>
           </div>
 
-          {/* Main CTA */}
+          {/* Main CTAs */}
+          <div className="flex items-center gap-2">
+            <Button
+              size="lg"
+              variant="outline"
+              className="gap-2"
+              onClick={() => setIsCredentialModalOpen(true)}
+            >
+              <IconCertificate className="h-5 w-5" />
+              Emitir Credencial
+            </Button>
           <AlertDialog
             open={certifyDialogOpen}
             onOpenChange={setCertifyDialogOpen}
@@ -213,6 +226,7 @@ export function EntrepreneurDetailPage({
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
+          </div>
         </div>
       </div>
 
@@ -475,6 +489,14 @@ export function EntrepreneurDetailPage({
           </div>
         </div>
       </div>
+
+      <CredentialIssuanceModal
+        open={isCredentialModalOpen}
+        onOpenChange={setIsCredentialModalOpen}
+        entrepreneurId={entrepreneur.id}
+        entrepreneurName={entrepreneur.name}
+        businessName={entrepreneur.businessName}
+      />
     </div>
   );
 }

--- a/frontend/src/features/entrepreneurs/components/pages/EntrepreneurDetailPage.tsx
+++ b/frontend/src/features/entrepreneurs/components/pages/EntrepreneurDetailPage.tsx
@@ -178,54 +178,54 @@ export function EntrepreneurDetailPage({
               <IconCertificate className="h-5 w-5" />
               Emitir Credencial
             </Button>
-          <AlertDialog
-            open={certifyDialogOpen}
-            onOpenChange={setCertifyDialogOpen}
-          >
-            <AlertDialogTrigger
-              render={
-                <Button
-                  size="lg"
-                  className="gap-2 shadow-lg bg-accent hover:bg-accent/90 text-accent-foreground"
-                  disabled={!nextStageToCertify}
-                  onClick={() =>
-                    nextStageToCertify &&
-                    setSelectedStageId(nextStageToCertify.id)
-                  }
-                >
-                  <Shield className="h-5 w-5" />
-                  {nextStageToCertify
-                    ? `Aprobar Etapa ${nextStageToCertify.id}`
-                    : 'Todas las etapas certificadas'}
-                </Button>
-              }
-            />
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  Aprobar Certificación - Etapa {selectedStageId}
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  Esta acción emitirá una credencial verificable en blockchain
-                  certificando que {entrepreneur.name} ha completado la etapa
-                  &quot;
-                  {STAGES.find((s) => s.id === selectedStageId)?.name}&quot;.
-                  Esta acción no se puede deshacer.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={() =>
-                    selectedStageId && handleCertifyStage(selectedStageId)
-                  }
-                >
-                  <Shield className="h-4 w-4 mr-2" />
-                  Emitir Credencial
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+            <AlertDialog
+              open={certifyDialogOpen}
+              onOpenChange={setCertifyDialogOpen}
+            >
+              <AlertDialogTrigger
+                render={
+                  <Button
+                    size="lg"
+                    className="gap-2 shadow-lg bg-accent hover:bg-accent/90 text-accent-foreground"
+                    disabled={!nextStageToCertify}
+                    onClick={() =>
+                      nextStageToCertify &&
+                      setSelectedStageId(nextStageToCertify.id)
+                    }
+                  >
+                    <Shield className="h-5 w-5" />
+                    {nextStageToCertify
+                      ? `Aprobar Etapa ${nextStageToCertify.id}`
+                      : 'Todas las etapas certificadas'}
+                  </Button>
+                }
+              />
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    Aprobar Certificación - Etapa {selectedStageId}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Esta acción emitirá una credencial verificable en blockchain
+                    certificando que {entrepreneur.name} ha completado la etapa
+                    &quot;
+                    {STAGES.find((s) => s.id === selectedStageId)?.name}&quot;.
+                    Esta acción no se puede deshacer.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() =>
+                      selectedStageId && handleCertifyStage(selectedStageId)
+                    }
+                  >
+                    <Shield className="h-4 w-4 mr-2" />
+                    Emitir Credencial
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Cambios realizados
Tipos actualizados: CredentialType ahora es 'impact' | 'behavior' | 'profile' (antes: impact, verification, endorsement), alineado con los schemas W3C de resources/.

3 schemas Zod nuevos en features/credentials/schemas/: uno por tipo de credencial, con campos calculados automaticos (margen operativo, variacion de ventas, ratio pasivos/activos).

Modal de emisión de credenciales (CredentialIssuanceModal.tsx): flujo de 3 pasos (Tipo → Datos → Emitida), header con stepper, formularios dinamicos por tipo. Preparado para ACTA con TODOs marcados.

Pagina /credentials/new reescrita: ahora muestra lista de empresarios con buscador; al seleccionar uno, abre el modal. Se removio el auth guard que redirigía a /login (inexistente).

Boton "Emitir Credencial" agregado en EntrepreneurDetailPage que abre el mismo modal con el contexto del empresario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-step credential issuance workflow supporting three credential types: Impact, Behavior, and Profile.
  * Added credential type selector with specialized forms for capturing relevant data for each credential type.
  * Added entrepreneur search and selection interface for initiating credential issuance.
  * Added success confirmation screen displaying issued credential details.
  * Added credential issuance shortcut button to entrepreneur profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->