### PR TITLE
fix: make social security and pension fields optional 

### DIFF
--- a/frontend/src/features/credentials/schemas/profileCredentialSchema.ts
+++ b/frontend/src/features/credentials/schemas/profileCredentialSchema.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const socialSecurityCoverageSchema = z.object({
-  hasSocialSecurity: z.boolean(),
-  hasPension: z.boolean(),
+  hasSocialSecurity: z.boolean().optional(),
+  hasPension: z.boolean().optional(),
   notes: z.string().optional(),
 });
 


### PR DESCRIPTION
This pull request makes a minor update to the `socialSecurityCoverageSchema` in `profileCredentialSchema.ts`, making the `hasSocialSecurity` and `hasPension` fields optional instead of required booleans. This allows for greater flexibility when these values are not provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Social security and pension coverage fields are now optional when submitting credential information, allowing users to skip these fields when not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->